### PR TITLE
Ignore missing callback and scope arguments

### DIFF
--- a/src/EventBus.js
+++ b/src/EventBus.js
@@ -34,6 +34,9 @@ EventBusClass.prototype = {
 	hasEventListener:function(type, callback, scope) {
 		if(typeof this.listeners[type] != "undefined") {
 			var numOfCallbacks = this.listeners[type].length;
+			if(callback === undefined && scope === undefined){
+				return numOfCallbacks > 0;
+			}
 			for(var i=0; i<numOfCallbacks; i++) {
 				var listener = this.listeners[type][i];
 				if(listener.scope == scope && listener.callback == callback) {


### PR DESCRIPTION
If we add a listener this way:

EventBus.addEventHandler("my_event", function(){});

then there is no scope and the funciton is anonymous.

If we then try to check if somebody is listening to the event "my_event"

EventBus.hasEventListener("my_event");

we'll get false (which is not true as we just created a listener for that event!)

This patch fixes that.
