### PR TITLE
Copy listener array using slice

### DIFF
--- a/src/EventBus.js
+++ b/src/EventBus.js
@@ -58,7 +58,6 @@
 			return false;
 		},
 		dispatch:function(type, target) {
-			var numOfListeners = 0;
 			var event = {
 				type:type,
 				target:target
@@ -70,14 +69,16 @@
 			};				
 			args = args.length > 2 ? args.splice(2, args.length-1) : [];
 			args = [event].concat(args);
-			if(typeof this.listeners[type] != "undefined") {
-				var numOfCallbacks = this.listeners[type].length;
+			
+			var listeners = this.listeners.slice();
+			
+			if(typeof listeners[type] != "undefined") {
+				var numOfCallbacks = listeners[type].length;
 				for(var i=0; i<numOfCallbacks; i++) {
-					var listener = this.listeners[type][i];
-					if(listener && listener.callback) {					
+					var listener = listeners[type][i];
+					if(listener && listener.callback && this.listeners.indexOf(listener) > -1) {					
 						var concatArgs = args.concat(listener.args);
 						listener.callback.apply(listener.scope, concatArgs);
-						numOfListeners += 1;
 					}
 				}
 			}

--- a/src/EventBus.js
+++ b/src/EventBus.js
@@ -76,7 +76,7 @@
 				var numOfCallbacks = listeners[type].length;
 				for(var i=0; i<numOfCallbacks; i++) {
 					var listener = listeners[type][i];
-					if(listener && listener.callback && this.listeners.indexOf(listener) > -1) {					
+					if(listener && listener.callback) {					
 						var concatArgs = args.concat(listener.args);
 						listener.callback.apply(listener.scope, concatArgs);
 					}


### PR DESCRIPTION
Handle the case where a listener could be removed as the result of another listener firing.

For example:
```js
function doThing() {
  bus.removeEventListener('fire', doOtherThing);
}

bus.addEventListener('fire', doThing);
bus.addEventListener('fire', doOtherThing);
bus.addEventListener('fire', doThirdThing);
```

The current implementation would skip `doThirdThing` because the `this.listeners[type]` array was modified while it was being looped through. If we slice the listeners first, it avoids this issue.

Note that a listener can not prevent another listener from firing within the same instance of a single event, which makes sense. If this is desired behavior though, you can add a check for ` && this.listeners.indexOf(listener) > -1` within the dispatch loop. I don't recommend it though, because the order in which listeners fire is solely determined by the order they were added.
